### PR TITLE
fix: correct failure with 'strict mode'

### DIFF
--- a/grammar/basic.js
+++ b/grammar/basic.js
@@ -1,9 +1,9 @@
 const
 
-decimal = /[0-9][0-9_]*/
-exponent = /[eE][+-]?[0-9_]+/
-hex_exponent = /[pP][+-]?[0-9a-fA-F_]+/
-magic_hash = rule => token(seq(rule, optional(token.immediate(/##?/))))
+  decimal = /[0-9][0-9_]*/,
+  exponent = /[eE][+-]?[0-9_]+/,
+  hex_exponent = /[pP][+-]?[0-9a-fA-F_]+/,
+  magic_hash = rule => token(seq(rule, optional(token.immediate(/##?/))))
 
 module.exports = {
   // ------------------------------------------------------------------------

--- a/grammar/id.js
+++ b/grammar/id.js
@@ -1,4 +1,4 @@
-const {parens, varid_pattern} = require('./util.js')
+const { brackets, ticked, parens, qualified, quote, varid_pattern } = require('./util.js')
 
 module.exports = {
   // ------------------------------------------------------------------------

--- a/grammar/import.js
+++ b/grammar/import.js
@@ -1,4 +1,4 @@
-const {parens} = require('./util.js')
+const { parens, sep1 } = require('./util.js')
 
 module.exports = {
   // ------------------------------------------------------------------------

--- a/grammar/module.js
+++ b/grammar/module.js
@@ -1,4 +1,4 @@
-const {parens} = require('./util.js')
+const { parens, qualified, sep, sep1 } = require('./util.js')
 
 module.exports = {
   // ------------------------------------------------------------------------

--- a/grammar/type.js
+++ b/grammar/type.js
@@ -1,6 +1,6 @@
 // from tree-sitter-haskell
 
-const {parens} = require('./util.js')
+const { braces, brackets, parens, quote, sep1, sep2 } = require('./util.js')
 
 module.exports = {
   // ------------------------------------------------------------------------

--- a/grammar/util.js
+++ b/grammar/util.js
@@ -1,24 +1,24 @@
 const
 
-parens = (...rule) => seq('(', ...rule, ')')
+  parens = (...rule) => seq('(', ...rule, ')'),
 
-braces = (...rule) => seq('{', ...rule, '}')
+  braces = (...rule) => seq('{', ...rule, '}'),
 
-brackets = (...rule) => seq('[', ...rule, ']')
+  brackets = (...rule) => seq('[', ...rule, ']'),
 
-ticked = (...rule) => seq('`', ...rule, '`')
+  ticked = (...rule) => seq('`', ...rule, '`'),
 
-quote = '\''
+  quote = '\'',
 
-qualified = ($, id) => seq($._qualifying_module, id)
+  qualified = ($, id) => seq($._qualifying_module, id),
 
-sep = (sep, rule) => optional(seq(rule, repeat(seq(sep, rule))))
+  sep = (sep, rule) => optional(seq(rule, repeat(seq(sep, rule)))),
 
-sep1 = (sep, rule) => seq(rule, repeat(seq(sep, rule)))
+  sep1 = (sep, rule) => seq(rule, repeat(seq(sep, rule))),
 
-sep2 = (sep, rule) => seq(rule, repeat1(seq(sep, rule)))
+  sep2 = (sep, rule) => seq(rule, repeat1(seq(sep, rule))),
 
-varid_pattern = /[_\p{Ll}](\w|')*#?/u
+  varid_pattern = /[_\p{Ll}](\w|')*#?/u
 
 module.exports = {
   parens,


### PR DESCRIPTION
The grammar will fail to evaluate if JS is run in 'strict mode', since the variable assignments are assigning them as globals, which is disallowed in strict mode. Also, they are not imported correctly in other files.